### PR TITLE
制作物・質問投稿画面のそれぞれの投稿ボタンを右下に配置

### DIFF
--- a/src/components/PostForm.jsx
+++ b/src/components/PostForm.jsx
@@ -267,7 +267,10 @@ function PostForm({
                     )}
                 </div>
 
-                <div style={{ display: 'flex', gap: '20px', alignItems: 'center', marginTop: '20px' }}>
+                <div style={{ display: 'flex',
+                        justifyContent: 'flex-end',
+                        marginTop: '20px',
+                        width: '100%' }}>
                     <button type="submit" disabled={loading} style={{ padding: '10px 30px', cursor: 'pointer', fontWeight: 'bold' }}>
                         {loading ? '送信中...' : submitButtonText}
                     </button>


### PR DESCRIPTION
制作物・質問投稿画面のそれぞれの投稿ボタンを右下に配置
<img width="1896" height="873" alt="スクリーンショット 2026-05-21 095724" src="https://github.com/user-attachments/assets/46f20962-2670-42c6-8bab-9e9fd9551776" />
<img width="1903" height="878" alt="スクリーンショット 2026-05-21 095845" src="https://github.com/user-attachments/assets/ea7228fd-f76e-478c-bcf4-41665e300b21" />
<img width="1920" height="877" alt="スクリーンショット 2026-05-21 103304" src="https://github.com/user-attachments/assets/f890c42a-392a-4c93-93b3-8ba72cb83d4d" />
<img width="1915" height="881" alt="スクリーンショット 2026-05-21 103526" src="https://github.com/user-attachments/assets/91f2c5d1-2512-4ad6-bc7e-5361e6d23efd" />
